### PR TITLE
feat(main): Added threshold for notifying

### DIFF
--- a/main.py
+++ b/main.py
@@ -199,10 +199,17 @@ def alertDiscord(centers, district, hook):
         else:
             currentColor = GREEN_ALERT
 
+        if totalSlots < 5:
+            # If slots are less than 5, do not @mention them. Just notify still.
+            content = f"Slots available at {district}!"
+        else:
+            # Else, we @mention and let everyone know.
+            content = mention
+
         requests.post(
             hook,
             json={
-                "content": f"{mention}",
+                "content": content,
                 "embeds": [
                     {
                         "title": f"Total slots: {totalSlots} for {date}",


### PR DESCRIPTION
Now users will be notified only if more than 5 or more slots are available. There will be no @mentions if there are less than 5 open slots in total.